### PR TITLE
Add terraform code to provision WRI ODP infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ The `vpc` module takes care of provisioning a Virtual Private Cloud (VPC) and ne
 The module contains the following files with their functionalities:
 
 - `main.tf`: Uses the open-source module `terraform-aws-modules/vpc/aws` to deploy the VPC.
-- Uses a single NAT gateway and enables DNS hostname and DNS support.
-- Tags the VPC with the environment name.
-- Adds a security group to allow traffic to the RDS instance on port 5432.
+  - Uses a single NAT gateway and enables DNS hostname and DNS support.
+  - Tags the VPC with the environment name.
+  - Adds a security group to allow traffic to the RDS instance on port 5432.
 
 Each of these modules plays a crucial role in building and maintaining your Kubernetes-based infrastructure. In the following sections, we will delve into the specific configurations and usage of each module.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,113 @@
-# wri-odp-infrastructure
-Infrastructure for the WRI Open Data Portal
+# WRI Open Data Portal Infrastructure
+
+This repository contains Terraform scripts designed to provision the infrastructure for the WRI Open Data Portal. The infrastructure is built to support containerized applications deployed on an Amazon Elastic Kubernetes Service (EKS) cluster hosted on AWS. Additionally, it utilizes a managed PostgreSQL server for data storage and management, along with provisioning an S3 file store for backend storage.
+
+These scripts enable the automated setup and management of the infrastructure components required to host and maintain the WRI Open Data Portal.
+
+## Table of Contents
+
+- [Remote State and State Locking](#remote-state-and-state-locking)
+- [Directory Structure](#directory-structure)
+- [IAM Service Account](#iam-service-account)
+- [k8s-infrastructure Modules](#k8s-infrastructure-modules)
+  - [ecr](#ecr)
+  - [eks](#eks)
+  - [rds](#rds)
+  - [s3](#s3)
+  - [vpc](#vpc)
+- [Usage](#usage)
+
+## Remote State and State Locking
+
+The Terraform setup employs a remote backend for storing the state file. The remote state storage configuration is defined in the `backend.tf` file.
+
+Additionally, to ensure safe and concurrent access to the Terraform state, the [state locking](https://developer.hashicorp.com/terraform/language/state/locking) feature is enabled, leveraging DynamoDB for this purpose.
+
+## Directory Structure
+
+The Terraform setup is organized into two main directories:
+
+1. **env**: This directory contains environment-specific files (e.g., dev, staging, prod) that use the modules located in the `k8s-infrastructure` directory. Environment variables are passed from this directory to the modules in `k8s-infrastructure`.
+
+2. **k8s-infrastructure**: This directory contains various modules for infrastructure provisioning. These modules are called from the `main.tf` file within the `k8s-infrastructure` directory, utilizing the variables provided by the `env/<env_name>` folder, where `terraform plan` and `terraform apply` commands are executed.
+
+## IAM Service Account
+
+An IAM Service Account user for Terraform is added without console access, with least privilege permissions (only the permissions required for provisioning the needed components). It is created to provision the architecture with tags like "Purpose: Terraform Automation" and "Application: WRI ODP" to help differentiate between different service accounts.
+
+## k8s-infrastructure Modules
+
+The `k8s-infrastructure` directory contains several modules, each responsible for specific infrastructure provisioning tasks. Below, we provide detailed explanations for each module:
+
+### ecr
+
+The `ecr` module is used for storing built Docker images, which are essential for deploying applications in your Kubernetes cluster. It ensures a reliable and versioned repository for your container images.
+
+The module contains the following files with their functionalities:
+
+- `main.tf`: This adds a private ECR registry with IMMUTABLE images.
+
+### eks
+
+The `eks` module is responsible for provisioning and managing an Amazon Elastic Kubernetes Service (EKS) cluster. EKS provides a scalable and managed Kubernetes environment, making it easier to deploy, manage, and scale containerized applications.
+
+The module contains the following files with their functionalities:
+
+- `main.tf`: It uses the module [terraform-aws-modules/eks/aws](https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest) for provisioning the EKS cluster with one managed node group.
+  - Uses IAM Roles for Service Accounts (IRSA) to grant roles to applications running in the EKS cluster.
+  - Managed node group (i.e., node group 1) with "t3.xlarge" instance type, tagged with the deployed environment.
+- `iam.tf`: We create an IAM role with access to EKS with necessary permissions.
+  - Provide Describe Cluster access to the role to access the cluster.
+  - IAM role (eks-admin) is created, which is bound to the Kubernetes system masters RBAC group to allow full access to the Kubernetes API.
+  - With trusted_role_arn, every user can assume the role if the user has needed policies attached to it.
+  - Allow users to assume a role that has access to EKS.
+  - Enable the EKS cluster `manage_aws_auth_configmap` and allow the role we just created in the aws_auth_roles (i.e., mapping eks-admin role with the Kubernetes system master RBAC group).
+- `autoscaler-iam.tf` and `autoscaler-manifest.tf`: Uses OIDC provider for IAM role service account.
+  - Adds Cluster autoscaler to automatically scale the EKS cluster using the manifest files.
+- `csi-driver-iam.tf` and `csi-driver-addons.tf`: Add EBS CSI driver as an add-on to ensure that we can attach volumes to the pods along with the user permissions needed for the IAM role.
+- `helm.tf`: Deploys nginx ingress controller and cert-manager.
+
+### rds
+
+The `rds` module handles the provisioning of a PostgreSQL database server. This database server is crucial for your applications, providing a secure and scalable storage solution for data.
+
+The module contains the following files with their functionalities:
+
+- `main.tf`: To create a PostgreSQL instance depending on the values provided to it via environment variables.
+
+### s3
+
+The `s3` module manages the provisioning of backend storage using Amazon S3. This storage is utilized by your applications to store and retrieve various data types, such as static assets, logs, and backups.
+
+The module contains the following files with their functionalities:
+
+- `main.tf`: Creates a private bucket for storing backend files for the WRI ODP.
+
+### vpc
+
+The `vpc` module takes care of provisioning a Virtual Private Cloud (VPC) and network policies for your entire infrastructure. It ensures a secure and isolated network environment for your Kubernetes cluster and associated resources.
+
+The module contains the following files with their functionalities:
+
+- `main.tf`: Uses the open-source module `terraform-aws-modules/vpc/aws` to deploy the VPC.
+- Uses a single NAT gateway and enables DNS hostname and DNS support.
+- Tags the VPC with the environment name.
+- Adds a security group to allow traffic to the RDS instance on port 5432.
+
+Each of these modules plays a crucial role in building and maintaining your Kubernetes-based infrastructure. In the following sections, we will delve into the specific configurations and usage of each module.
+
+## Usage
+
+### How to deploy
+
+1. Clone the repository locally and ensure that you have the credentials for the Terraform user already set up in your environment.
+
+2. Navigate to the `env` directory corresponding to your working environment (e.g., `cd env/dev`).
+
+3. Add the necessary environment variables in `.auto.tfvars`.
+
+4. Run `terraform plan`. For example, if you are in the `env/dev` directory, run `terraform plan` after adding `.auto.tfvars`.
+
+5. Run `terraform apply` once everything in the plan seems satisfactory.
+
+These steps will allow you to deploy and manage the infrastructure efficiently.

--- a/env/dev/backend.tf
+++ b/env/dev/backend.tf
@@ -1,0 +1,31 @@
+resource "aws_s3_bucket" "tfm_state_bucket" {
+  bucket = "wri-odp-tfm-state-bucket"
+}
+
+resource "aws_s3_bucket_versioning" "tfm_state_bucket_versioning" {
+  bucket = aws_s3_bucket.tfm_state_bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tfm_state_bucket_encryption" {
+  bucket = aws_s3_bucket.tfm_state_bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_dynamodb_table" "tfm_state_lock" {
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+  name         = "tfm-state-lock"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}

--- a/env/dev/main.tf
+++ b/env/dev/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  backend "s3" {
+    bucket         = "wri-odp-tfm-state-bucket"
+    dynamodb_table = "tfm-state-lock"
+    key            = "global/statefile/terraform.state"
+    region         = "us-east-1"
+    encrypt        = true
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "infrastructure" {
+  source                     = "../../k8s-infrastructure"
+  availability_zones         = var.availability_zones
+  private_subnet_cidr_blocks = var.private_subnet_cidr_blocks
+  public_subnet_cidr_blocks  = var.public_subnet_cidr_blocks
+  db_subnet_cidr_blocks      = var.db_subnet_cidr_blocks
+  project_env                = var.project_env
+  postgres                   = var.postgres
+  ckan_storage               = var.s3_ckan_storage
+  cluster_name               = var.s3_cluster_name
+  cluster_issuer             = var.cluster_issuer
+}
+
+
+

--- a/env/dev/main.tf
+++ b/env/dev/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 provider "aws" {
-  region = var.aws_region
+  region  = var.aws_region
 }
 
 module "infrastructure" {
@@ -17,6 +17,7 @@ module "infrastructure" {
   availability_zones         = var.availability_zones
   private_subnet_cidr_blocks = var.private_subnet_cidr_blocks
   public_subnet_cidr_blocks  = var.public_subnet_cidr_blocks
+  sg_rds_cidr_block          = var.sg_rds_cidr_block
   db_subnet_cidr_blocks      = var.db_subnet_cidr_blocks
   project_env                = var.project_env
   postgres                   = var.postgres

--- a/env/dev/variables.tf
+++ b/env/dev/variables.tf
@@ -66,3 +66,9 @@ variable "db_subnet_cidr_blocks" {
   default     = ["10.0.7.0/24", "10.0.8.0/24", "10.0.9.0/24"]
   description = "A list of CIDR ranges for db subnets."
 }
+
+variable "sg_rds_cidr_block" {
+  default     = ["10.0.0.0/8"]
+  type        = list(string)
+  description = "The CIDR range for the RDS security Group"
+}

--- a/env/dev/variables.tf
+++ b/env/dev/variables.tf
@@ -1,0 +1,68 @@
+variable "aws_region" {
+  default = "us-east-1"
+}
+variable "s3_ckan_storage" {
+  default = "storage"
+}
+variable "s3_cluster_name" {
+  default = "ckan-dev"
+}
+
+variable "postgres" {
+  default = {
+    instance_name      = "dx-ckan-db"
+    family             = "postgres11"
+    instance_class     = "db.t3.micro"
+    instance_version   = "11.19"
+    database_name      = "ckan"
+    database_user_name = "postgres"
+    allocated_storage  = "5"
+    backup_retention   = 7
+    maintenance_window = "Mon:00:00-Mon:03:00"
+    backup_window      = "03:00-06:00"
+  }
+
+  type = object({
+    instance_name      = string
+    family             = string
+    instance_class     = string
+    database_name      = string
+    instance_version   = string
+    database_user_name = string
+    allocated_storage  = string
+    maintenance_window = string
+    backup_window      = string
+    backup_retention   = number
+  })
+
+}
+
+variable "cluster_issuer" {
+  default = {
+    private_key = "key"
+    email       = "test@email.com"
+  }
+}
+
+variable "project_env" {}
+
+variable "availability_zones" {
+  default     = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  description = "A list of availability zones for subnet placement."
+}
+
+
+variable "private_subnet_cidr_blocks" {
+  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  description = "A list of CIDR ranges for private subnets."
+}
+
+variable "public_subnet_cidr_blocks" {
+  default     = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  description = "A list of CIDR ranges for public subnets."
+}
+
+variable "db_subnet_cidr_blocks" {
+  default     = ["10.0.7.0/24", "10.0.8.0/24", "10.0.9.0/24"]
+  description = "A list of CIDR ranges for db subnets."
+}

--- a/k8s-infrastructure/main.tf
+++ b/k8s-infrastructure/main.tf
@@ -1,0 +1,42 @@
+module "ckan_vpc" {
+  source = "./modules/vpc"
+  project_env = var.project_env
+  cluster_name = var.cluster_name
+  availability_zones             = var.availability_zones
+  private_subnet_cidr_blocks = var.private_subnet_cidr_blocks
+  public_subnet_cidr_blocks       = var.public_subnet_cidr_blocks
+  db_subnet_cidr_blocks = var.db_subnet_cidr_blocks
+}
+
+module "ckan_eks" {
+  source                = "./modules/eks"
+  cluster_name          = var.cluster_name
+  vpc_id                = module.ckan_vpc.vpc_id
+  subnet_ids            = module.ckan_vpc.subnet_ids
+  aws_security_group_id = module.ckan_vpc.security_group_id
+  vpc_owner_id          = module.ckan_vpc.owner_id
+  cluster_issuer        = var.cluster_issuer
+  project_env = var.project_env
+
+}
+
+module "ckan_rds" {
+  source                = "./modules/rds"
+  db_subnet_group       = module.ckan_vpc.db_subnet_group
+  security_group_rds_id = module.ckan_vpc.security_group_rds_id
+  postgres              = var.postgres
+  depends_on = [module.ckan_vpc]
+}
+
+module "ckan_storage" {
+  source       = "./modules/s3"
+  storage      = var.ckan_storage
+  cluster_name = var.cluster_name
+
+}
+
+module "ckan_ecr" {
+  source = "./modules/ecr"
+  cluster_name = var.cluster_name
+}
+

--- a/k8s-infrastructure/main.tf
+++ b/k8s-infrastructure/main.tf
@@ -1,11 +1,11 @@
 module "ckan_vpc" {
-  source = "./modules/vpc"
-  project_env = var.project_env
-  cluster_name = var.cluster_name
-  availability_zones             = var.availability_zones
+  source                     = "./modules/vpc"
+  project_env                = var.project_env
+  cluster_name               = var.cluster_name
+  availability_zones         = var.availability_zones
   private_subnet_cidr_blocks = var.private_subnet_cidr_blocks
-  public_subnet_cidr_blocks       = var.public_subnet_cidr_blocks
-  db_subnet_cidr_blocks = var.db_subnet_cidr_blocks
+  public_subnet_cidr_blocks  = var.public_subnet_cidr_blocks
+  db_subnet_cidr_blocks      = var.db_subnet_cidr_blocks
 }
 
 module "ckan_eks" {
@@ -16,7 +16,7 @@ module "ckan_eks" {
   aws_security_group_id = module.ckan_vpc.security_group_id
   vpc_owner_id          = module.ckan_vpc.owner_id
   cluster_issuer        = var.cluster_issuer
-  project_env = var.project_env
+  project_env           = var.project_env
 
 }
 
@@ -25,7 +25,7 @@ module "ckan_rds" {
   db_subnet_group       = module.ckan_vpc.db_subnet_group
   security_group_rds_id = module.ckan_vpc.security_group_rds_id
   postgres              = var.postgres
-  depends_on = [module.ckan_vpc]
+  depends_on            = [module.ckan_vpc]
 }
 
 module "ckan_storage" {
@@ -36,7 +36,7 @@ module "ckan_storage" {
 }
 
 module "ckan_ecr" {
-  source = "./modules/ecr"
+  source       = "./modules/ecr"
   cluster_name = var.cluster_name
 }
 

--- a/k8s-infrastructure/main.tf
+++ b/k8s-infrastructure/main.tf
@@ -6,6 +6,7 @@ module "ckan_vpc" {
   private_subnet_cidr_blocks = var.private_subnet_cidr_blocks
   public_subnet_cidr_blocks  = var.public_subnet_cidr_blocks
   db_subnet_cidr_blocks      = var.db_subnet_cidr_blocks
+  sg_rds_cidr_block          = var.sg_rds_cidr_block
 }
 
 module "ckan_eks" {
@@ -13,7 +14,7 @@ module "ckan_eks" {
   cluster_name          = var.cluster_name
   vpc_id                = module.ckan_vpc.vpc_id
   subnet_ids            = module.ckan_vpc.subnet_ids
-  aws_security_group_id = module.ckan_vpc.security_group_id
+  #aws_security_group_id = module.ckan_vpc.security_group_id
   vpc_owner_id          = module.ckan_vpc.owner_id
   cluster_issuer        = var.cluster_issuer
   project_env           = var.project_env

--- a/k8s-infrastructure/modules/ecr/main.tf
+++ b/k8s-infrastructure/modules/ecr/main.tf
@@ -1,0 +1,7 @@
+resource "aws_ecr_repository" "default" {
+  name                 = "${var.cluster_name}-ecr"
+  image_tag_mutability = var.ecr.mutability
+  image_scanning_configuration {
+    scan_on_push = var.ecr.scan_on_push
+  }
+}

--- a/k8s-infrastructure/modules/ecr/variables.tf
+++ b/k8s-infrastructure/modules/ecr/variables.tf
@@ -1,0 +1,13 @@
+variable "cluster_name" { }
+
+variable "ecr" {
+  default = {
+    scan_on_push = false
+    mutability   = "MUTABLE"
+  }
+
+  type = object({
+    scan_on_push = bool
+    mutability   = string
+  })
+}

--- a/k8s-infrastructure/modules/ecr/variables.tf
+++ b/k8s-infrastructure/modules/ecr/variables.tf
@@ -3,7 +3,7 @@ variable "cluster_name" { }
 variable "ecr" {
   default = {
     scan_on_push = false
-    mutability   = "MUTABLE"
+    mutability   = "IMMUTABLE"
   }
 
   type = object({

--- a/k8s-infrastructure/modules/eks/autoscaler-iam.tf
+++ b/k8s-infrastructure/modules/eks/autoscaler-iam.tf
@@ -1,0 +1,15 @@
+module "cluster_autoscaler_irsa_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.3.1"
+
+  role_name                        = "cluster-autoscaler"
+  attach_cluster_autoscaler_policy = true
+  cluster_autoscaler_cluster_ids   = [module.eks.cluster_name]
+
+  oidc_providers = {
+    ex = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:cluster-autoscaler"]
+    }
+  }
+}

--- a/k8s-infrastructure/modules/eks/autoscaler-manifest.tf
+++ b/k8s-infrastructure/modules/eks/autoscaler-manifest.tf
@@ -1,8 +1,8 @@
 provider "kubectl" {
-  host = data.aws_eks_cluster.default.endpoint
+  host                   = data.aws_eks_cluster.default.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.default.certificate_authority[0].data)
-  load_config_file = false
-  token            = data.aws_eks_cluster_auth.default.token
+  load_config_file       = false
+  token                  = data.aws_eks_cluster_auth.default.token
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"
     args        = ["eks", "get-token", "--cluster-name", var.cluster_name]

--- a/k8s-infrastructure/modules/eks/autoscaler-manifest.tf
+++ b/k8s-infrastructure/modules/eks/autoscaler-manifest.tf
@@ -1,0 +1,202 @@
+provider "kubectl" {
+  host = data.aws_eks_cluster.default.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.default.certificate_authority[0].data)
+  load_config_file = false
+  token            = data.aws_eks_cluster_auth.default.token
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    args        = ["eks", "get-token", "--cluster-name", var.cluster_name]
+    command     = "aws"
+  }
+}
+
+resource "kubectl_manifest" "service_account" {
+  yaml_body = <<-EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: kube-system
+  annotations:
+    eks.amazonaws.com/role-arn: ${module.cluster_autoscaler_irsa_role.iam_role_arn}
+EOF
+}
+
+resource "kubectl_manifest" "role" {
+  yaml_body = <<-EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create","list","watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]
+    verbs: ["delete", "get", "update", "watch"]
+EOF
+}
+
+resource "kubectl_manifest" "role_binding" {
+  yaml_body = <<-EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+EOF
+}
+
+resource "kubectl_manifest" "cluster_role" {
+  yaml_body = <<-EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["events", "endpoints"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    resourceNames: ["cluster-autoscaler"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["watch", "list", "get", "update"]
+  - apiGroups: [""]
+    resources:
+      - "namespaces"
+      - "pods"
+      - "services"
+      - "replicationcontrollers"
+      - "persistentvolumeclaims"
+      - "persistentvolumes"
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["batch", "extensions"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resourceNames: ["cluster-autoscaler"]
+    resources: ["leases"]
+    verbs: ["get", "update"]
+EOF
+}
+
+resource "kubectl_manifest" "cluster_role_binding" {
+  yaml_body = <<-EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+EOF
+}
+
+resource "kubectl_manifest" "deployment" {
+  yaml_body = <<-EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    app: cluster-autoscaler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  template:
+    metadata:
+      labels:
+        app: cluster-autoscaler
+    spec:
+      priorityClassName: system-cluster-critical
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
+      serviceAccountName: cluster-autoscaler
+      containers:
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.25.3
+          name: cluster-autoscaler
+          resources:
+            limits:
+              cpu: 100m
+              memory: 600Mi
+            requests:
+              cpu: 100m
+              memory: 600Mi
+          command:
+            - ./cluster-autoscaler
+            - --v=4
+            - --stderrthreshold=info
+            - --cloud-provider=aws
+            - --skip-nodes-with-local-storage=false
+            - --expander=least-waste
+            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/${module.eks.cluster_name}
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              readOnly: true
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: "/etc/ssl/certs/ca-bundle.crt"
+EOF
+}

--- a/k8s-infrastructure/modules/eks/csi-driver-addons.tf
+++ b/k8s-infrastructure/modules/eks/csi-driver-addons.tf
@@ -1,0 +1,6 @@
+resource "aws_eks_addon" "csi_driver" {
+  cluster_name             = module.eks.cluster_name
+  addon_name               = "aws-ebs-csi-driver"
+  addon_version            = "v1.22.0-eksbuild.2"
+  service_account_role_arn = aws_iam_role.eks_ebs_csi_driver.arn
+}

--- a/k8s-infrastructure/modules/eks/csi-driver-iam.tf
+++ b/k8s-infrastructure/modules/eks/csi-driver-iam.tf
@@ -1,0 +1,31 @@
+data "tls_certificate" "eks" {
+  url = data.aws_eks_cluster.default.identity[0].oidc[0].issuer
+}
+
+data "aws_iam_policy_document" "csi" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    condition {
+      test     = "StringEquals"
+      variable = "${module.eks.oidc_provider}:sub"
+      values   = ["system:serviceaccount:kube-system:ebs-csi-controller-sa"]
+    }
+
+    principals {
+      identifiers = [module.eks.oidc_provider_arn]
+      type        = "Federated"
+    }
+  }
+}
+
+resource "aws_iam_role" "eks_ebs_csi_driver" {
+  assume_role_policy = data.aws_iam_policy_document.csi.json
+  name               = "eks-ebs-csi-driver"
+}
+
+resource "aws_iam_role_policy_attachment" "amazon_ebs_csi_driver" {
+  role       = aws_iam_role.eks_ebs_csi_driver.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}

--- a/k8s-infrastructure/modules/eks/helm.tf
+++ b/k8s-infrastructure/modules/eks/helm.tf
@@ -1,0 +1,61 @@
+provider "helm" {
+  kubernetes {
+    host = data.aws_eks_cluster.default.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.default.certificate_authority[0].data)
+    token = data.aws_eks_cluster_auth.default.token
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      args        = ["eks", "get-token", "--cluster-name", var.cluster_name]
+      command     = "aws"
+    }
+  }
+}
+
+resource "helm_release" "sealed_secrets" {
+  name       = "sealed-secrets-controller"
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "sealed-secrets"
+}
+
+resource "helm_release" "ngnix_ingress" {
+  name       = "nginx-ingress-production"
+  chart      = "ingress-nginx"
+  repository = "https://kubernetes.github.io/ingress-nginx"
+  namespace  = "nginx-ingress"
+  version    = "4.4.0"
+
+  set {
+    name  = "rbac.create"
+    value = true
+  }
+
+  set {
+    name  = "controller.service.externalTrafficPolicy"
+    value = "Local"
+  }
+
+  set {
+    name  = "controller.publishService.enabled"
+    value = true
+  }
+
+  set {
+    name  = "controller.replicaCount"
+    value = "3"
+  }
+}
+
+
+variable "cluster_issuer" {
+  type = object({
+    private_key = string
+    email       = string
+  })
+}
+
+module "cert_manager" {
+  source                                 = "terraform-iaac/cert-manager/kubernetes"
+  version                                = "2.6.0"
+  cluster_issuer_email                   = var.cluster_issuer.email
+  cluster_issuer_private_key_secret_name = var.cluster_issuer.private_key
+}

--- a/k8s-infrastructure/modules/eks/helm.tf
+++ b/k8s-infrastructure/modules/eks/helm.tf
@@ -1,8 +1,8 @@
 provider "helm" {
   kubernetes {
-    host = data.aws_eks_cluster.default.endpoint
+    host                   = data.aws_eks_cluster.default.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.default.certificate_authority[0].data)
-    token = data.aws_eks_cluster_auth.default.token
+    token                  = data.aws_eks_cluster_auth.default.token
     exec {
       api_version = "client.authentication.k8s.io/v1beta1"
       args        = ["eks", "get-token", "--cluster-name", var.cluster_name]

--- a/k8s-infrastructure/modules/eks/iam.tf
+++ b/k8s-infrastructure/modules/eks/iam.tf
@@ -1,0 +1,78 @@
+module "allow_eks_access_iam_policy" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "5.3.1"
+
+  name          = "allow-eks-access"
+  create_policy = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "eks:DescribeCluster",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
+variable "vpc_owner_id" {}
+module "eks_admins_iam_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "5.3.1"
+
+  role_name         = "eks-admin"
+  create_role       = true
+  role_requires_mfa = false
+
+  custom_role_policy_arns = [module.allow_eks_access_iam_policy.arn]
+
+  trusted_role_arns = [
+    "arn:aws:iam::${var.vpc_owner_id}:root"
+  ]
+}
+
+module "dev_iam_user" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-user"
+  version = "5.3.1"
+
+  name                          = "dev1-datopian"
+  create_iam_access_key         = false
+  create_iam_user_login_profile = false
+
+  force_destroy = true
+}
+
+module "allow_assume_eks_admins_iam_policy" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "5.3.1"
+
+  name          = "allow-assume-eks-admin-iam-role"
+  create_policy = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "sts:AssumeRole",
+        ]
+        Effect   = "Allow"
+        Resource = module.eks_admins_iam_role.iam_role_arn
+      },
+    ]
+  })
+}
+
+module "eks_admins_iam_group" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-group-with-policies"
+  version = "5.3.1"
+
+  name                              = "eks-admin"
+  attach_iam_self_management_policy = false
+  create_group                      = true
+  group_users                       = [module.dev_iam_user.iam_user_name]
+  custom_group_policy_arns          = [module.allow_assume_eks_admins_iam_policy.arn]
+}

--- a/k8s-infrastructure/modules/eks/main.tf
+++ b/k8s-infrastructure/modules/eks/main.tf
@@ -3,13 +3,13 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "19.16.0"
 
-  cluster_name    = var.cluster_name
-  cluster_version = "1.25"
+  cluster_name                    = var.cluster_name
+  cluster_version                 = "1.25"
   cluster_endpoint_private_access = true
-  cluster_endpoint_public_access = true
-  vpc_id     = var.vpc_id
-  subnet_ids = var.subnet_ids
-  enable_irsa = true
+  cluster_endpoint_public_access  = true
+  vpc_id                          = var.vpc_id
+  subnet_ids                      = var.subnet_ids
+  enable_irsa                     = true
   eks_managed_node_group_defaults = {
     ami_type                              = "AL2_x86_64"
     attach_cluster_primary_security_group = true
@@ -24,10 +24,7 @@ module "eks" {
 
       min_size     = 1
       max_size     = 5
-      desired_size = 2
-      vpc_security_group_ids = [
-        var.aws_security_group_id
-      ]
+      desired_size = 3
     }
   }
   manage_aws_auth_configmap = true
@@ -59,7 +56,7 @@ data "aws_eks_cluster_auth" "default" {
 }
 
 provider "kubernetes" {
-  host = data.aws_eks_cluster.default.endpoint
+  host                   = data.aws_eks_cluster.default.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.default.certificate_authority[0].data)
   token                  = data.aws_eks_cluster_auth.default.token
 

--- a/k8s-infrastructure/modules/eks/main.tf
+++ b/k8s-infrastructure/modules/eks/main.tf
@@ -1,0 +1,87 @@
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "19.16.0"
+
+  cluster_name    = var.cluster_name
+  cluster_version = "1.25"
+  cluster_endpoint_private_access = true
+  cluster_endpoint_public_access = true
+  vpc_id     = var.vpc_id
+  subnet_ids = var.subnet_ids
+  enable_irsa = true
+  eks_managed_node_group_defaults = {
+    ami_type                              = "AL2_x86_64"
+    attach_cluster_primary_security_group = true
+    # Disabling and using externally provided security groups
+    create_security_group = false
+  }
+
+  eks_managed_node_groups = {
+    one = {
+      name           = "node-group-1"
+      instance_types = ["t3.xlarge"]
+
+      min_size     = 1
+      max_size     = 5
+      desired_size = 2
+      vpc_security_group_ids = [
+        var.aws_security_group_id
+      ]
+    }
+  }
+  manage_aws_auth_configmap = true
+
+  aws_auth_roles = [
+    {
+      rolearn  = module.eks_admins_iam_role.iam_role_arn
+      username = module.eks_admins_iam_role.iam_role_name
+      groups   = ["system:masters"]
+    },
+  ]
+  tags = {
+    Environment = var.project_env
+  }
+}
+
+
+# https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2009
+data "aws_eks_cluster" "default" {
+  #name = module.eks.cluster_name
+  name = var.cluster_name
+  #depends_on = [module.eks.cluster_name]
+}
+
+data "aws_eks_cluster_auth" "default" {
+  #name = module.eks.cluster_name
+  name = var.cluster_name
+  #depends_on = [module.eks.cluster_name]
+}
+
+provider "kubernetes" {
+  host = data.aws_eks_cluster.default.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.default.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.default.token
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1"
+    args        = ["eks", "get-token", "--cluster-name", var.cluster_name]
+    command     = "aws"
+  }
+}
+
+
+output "test-out" {
+  value = data.aws_eks_cluster.default.endpoint
+}
+output "eks_oidc" {
+  value = module.eks.oidc_provider_arn
+}
+
+output "aws_eks_cluster" {
+  value = data.aws_eks_cluster.default
+}
+
+output "aws_eks_cluster_auth" {
+  value = data.aws_eks_cluster_auth.default
+}

--- a/k8s-infrastructure/modules/eks/variables.tf
+++ b/k8s-infrastructure/modules/eks/variables.tf
@@ -1,8 +1,6 @@
 variable "cluster_name" {
   default = "ckan-dev-cluster"
 }
-
 variable "vpc_id" {}
 variable "subnet_ids" {}
-variable "aws_security_group_id" {}
 variable "project_env" {}

--- a/k8s-infrastructure/modules/eks/variables.tf
+++ b/k8s-infrastructure/modules/eks/variables.tf
@@ -1,0 +1,8 @@
+variable "cluster_name" {
+  default = "ckan-dev-cluster"
+}
+
+variable "vpc_id" {}
+variable "subnet_ids" {}
+variable "aws_security_group_id" {}
+variable "project_env" {}

--- a/k8s-infrastructure/modules/eks/versions.tf
+++ b/k8s-infrastructure/modules/eks/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.14.0"
+    }
+  }
+} 

--- a/k8s-infrastructure/modules/rds/main.tf
+++ b/k8s-infrastructure/modules/rds/main.tf
@@ -1,0 +1,24 @@
+module "db" {
+  source     = "terraform-aws-modules/rds/aws"
+  identifier = var.postgres.instance_name
+
+  engine         = "postgres"
+  family         = var.postgres.family
+  engine_version = var.postgres.instance_version
+  instance_class = var.postgres.instance_class
+
+  allocated_storage = var.postgres.allocated_storage
+
+  backup_retention_period = var.postgres.backup_retention
+  maintenance_window      = var.postgres.maintenance_window
+  backup_window           = var.postgres.backup_window
+
+  db_name  = var.postgres.database_name
+  username = var.postgres.database_user_name
+  port     = 5432
+
+  db_subnet_group_name = var.db_subnet_group
+  vpc_security_group_ids = [
+    var.security_group_rds_id
+  ]
+}

--- a/k8s-infrastructure/modules/rds/variables.tf
+++ b/k8s-infrastructure/modules/rds/variables.tf
@@ -1,0 +1,30 @@
+variable "postgres" {
+  default = {
+    instance_name      = "dx-ckan-db"
+    family             = "postgres11"
+    instance_class     = "db.t3.micro"
+    instance_version   = "11.19"
+    database_name      = "ckan"
+    database_user_name = "postgres"
+    allocated_storage  = "5"
+    backup_retention   = 7
+    maintenance_window = "Mon:00:00-Mon:03:00"
+    backup_window      = "03:00-06:00"
+  }
+
+  type = object({
+    instance_name      = string
+    family             = string
+    instance_class     = string
+    database_name      = string
+    instance_version   = string
+    database_user_name = string
+    allocated_storage  = string
+    maintenance_window = string
+    backup_window      = string
+    backup_retention   = number
+  })
+
+}
+variable "db_subnet_group" {}
+variable "security_group_rds_id" {}

--- a/k8s-infrastructure/modules/s3/main.tf
+++ b/k8s-infrastructure/modules/s3/main.tf
@@ -1,11 +1,14 @@
 
 /* Create the bucket  */
-resource "aws_s3_bucket" "default" {
+resource "aws_s3_bucket" "ckan_storage" {
   bucket = "${var.cluster_name}-${var.storage}"
 }
 
-variable "acl" {
-  type        = string
-  description = "Defaults to private "
-  default     = "private"
+resource "aws_s3_bucket_public_access_block" "ckan_storage_acl" {
+  bucket                  = aws_s3_bucket.ckan_storage.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
+

--- a/k8s-infrastructure/modules/s3/main.tf
+++ b/k8s-infrastructure/modules/s3/main.tf
@@ -1,0 +1,11 @@
+
+/* Create the bucket  */
+resource "aws_s3_bucket" "default" {
+  bucket = "${var.cluster_name}-${var.storage}"
+}
+
+variable "acl" {
+  type        = string
+  description = "Defaults to private "
+  default     = "private"
+}

--- a/k8s-infrastructure/modules/s3/variables.tf
+++ b/k8s-infrastructure/modules/s3/variables.tf
@@ -1,0 +1,8 @@
+
+variable "storage" {
+  type        = string
+  description = "(required since we are not using 'bucket') Creates a unique bucket name beginning with the specified prefix"
+  default     = "ckan-storage"
+}
+
+variable "cluster_name" { }

--- a/k8s-infrastructure/modules/s3/variables.tf
+++ b/k8s-infrastructure/modules/s3/variables.tf
@@ -5,4 +5,4 @@ variable "storage" {
   default     = "ckan-storage"
 }
 
-variable "cluster_name" { }
+variable "cluster_name" {}

--- a/k8s-infrastructure/modules/vpc/main.tf
+++ b/k8s-infrastructure/modules/vpc/main.tf
@@ -1,0 +1,83 @@
+module "vpc" {
+
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.1.1"
+  name    = "${var.cluster_name}-vpc"
+
+  cidr = var.cidr_block
+
+  azs                    = var.availability_zones
+  private_subnets        = var.private_subnet_cidr_blocks
+  public_subnets         = var.public_subnet_cidr_blocks
+  database_subnets       = var.db_subnet_cidr_blocks
+  enable_nat_gateway     = true
+  single_nat_gateway     = true
+  one_nat_gateway_per_az = false
+
+  # Common for many AWS Services to require DNS (e.g. EFS Filesystem in EKS CLuster)
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = 1
+  }
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb" = 1
+  }
+  tags = {
+    Environment = var.project_env
+  }
+
+}
+
+resource "aws_security_group" "node_group_one" {
+  name_prefix = "node_group_one"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+
+    cidr_blocks = [
+      "10.0.0.0/8",
+    ]
+  }
+}
+
+resource "aws_security_group" "rds" {
+  name_prefix = "ckan_db"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    from_port = 5432
+    to_port   = 5432
+    protocol  = "tcp"
+    cidr_blocks = [
+      "10.0.0.0/8",
+    ]
+  }
+}
+
+output "db_subnet_group" {
+  value = module.vpc.database_subnet_group
+}
+
+output "security_group_rds_id" {
+  value = aws_security_group.rds.id
+}
+
+output "security_group_id" {
+  value = aws_security_group.node_group_one.id
+}
+
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "subnet_ids" {
+  value = module.vpc.private_subnets
+}
+
+output "owner_id" {
+  value = module.vpc.vpc_owner_id
+}

--- a/k8s-infrastructure/modules/vpc/main.tf
+++ b/k8s-infrastructure/modules/vpc/main.tf
@@ -29,32 +29,17 @@ module "vpc" {
 
 }
 
-resource "aws_security_group" "node_group_one" {
-  name_prefix = "node_group_one"
-  vpc_id      = module.vpc.vpc_id
-
-  ingress {
-    from_port = 22
-    to_port   = 22
-    protocol  = "tcp"
-
-    cidr_blocks = [
-      "10.0.0.0/8",
-    ]
-  }
-}
-
 resource "aws_security_group" "rds" {
   name_prefix = "ckan_db"
+  description = "Security group for the RDS instance"
   vpc_id      = module.vpc.vpc_id
 
   ingress {
+    description = "Allow traffic to the RDS instance"
     from_port = 5432
     to_port   = 5432
     protocol  = "tcp"
-    cidr_blocks = [
-      "10.0.0.0/8",
-    ]
+    cidr_blocks = var.sg_rds_cidr_block
   }
 }
 
@@ -64,10 +49,6 @@ output "db_subnet_group" {
 
 output "security_group_rds_id" {
   value = aws_security_group.rds.id
-}
-
-output "security_group_id" {
-  value = aws_security_group.node_group_one.id
 }
 
 output "vpc_id" {

--- a/k8s-infrastructure/modules/vpc/variables.tf
+++ b/k8s-infrastructure/modules/vpc/variables.tf
@@ -19,7 +19,11 @@ variable "cidr_block" {
   type        = string
   description = "The CIDR range for the entire VPC."
 }
-
+variable "sg_rds_cidr_block" {
+  default     = ["10.0.0.0/8"]
+  type        = list(string)
+  description = "The CIDR range for the RDS security Group"
+}
 variable "availability_zones" {
   default     = ["us-east-1a", "us-east-1b", "us-east-1c"]
   description = "A list of availability zones for subnet placement."

--- a/k8s-infrastructure/modules/vpc/variables.tf
+++ b/k8s-infrastructure/modules/vpc/variables.tf
@@ -1,0 +1,50 @@
+variable "project_env" {
+  type        = string
+  description = "A project namespace for the infrastructure."
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "EKS cluster name for the infrastructure."
+}
+
+variable "aws_region" {
+  default     = "us-east-1"
+  type        = string
+  description = "A valid AWS region to configure the underlying AWS SDK."
+}
+
+variable "cidr_block" {
+  default     = "10.0.0.0/16" // 10.0.0.0 - 10.0.255.255
+  type        = string
+  description = "The CIDR range for the entire VPC."
+}
+
+variable "availability_zones" {
+  default     = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  description = "A list of availability zones for subnet placement."
+}
+
+
+variable "private_subnet_cidr_blocks" {
+  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  description = "A list of CIDR ranges for private subnets."
+}
+
+variable "public_subnet_cidr_blocks" {
+  default     = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  description = "A list of CIDR ranges for public subnets."
+}
+
+variable "db_subnet_cidr_blocks" {
+  default     = ["10.0.7.0/24", "10.0.8.0/24", "10.0.9.0/24"]
+  description = "A list of CIDR ranges for db subnets."
+}
+
+variable "cluster" {
+  default = {
+  name = "ckan-dev-cluster-test" }
+  type = object({
+    name = string
+  })
+}

--- a/k8s-infrastructure/variables.tf
+++ b/k8s-infrastructure/variables.tf
@@ -20,6 +20,12 @@ variable "private_subnet_cidr_blocks" {
   description = "A list of CIDR ranges for private subnets."
 }
 
+variable "sg_rds_cidr_block" {
+  default     = ["10.0.0.0/8"]
+  type        = list(string)
+  description = "The CIDR range for the RDS security Group"
+}
+
 variable "public_subnet_cidr_blocks" {
   default     = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
   description = "A list of CIDR ranges for public subnets."

--- a/k8s-infrastructure/variables.tf
+++ b/k8s-infrastructure/variables.tf
@@ -16,17 +16,17 @@ variable "availability_zones" {
 }
 
 variable "private_subnet_cidr_blocks" {
-  default     = ["10.0.1.0/24", "10.0.2.0/24","10.0.3.0/24"]
+  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   description = "A list of CIDR ranges for private subnets."
 }
 
 variable "public_subnet_cidr_blocks" {
-  default     = ["10.0.4.0/24", "10.0.5.0/24","10.0.6.0/24"]
+  default     = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
   description = "A list of CIDR ranges for public subnets."
 }
 
 variable "db_subnet_cidr_blocks" {
-  default     = ["10.0.7.0/24", "10.0.8.0/24","10.0.9.0/24"]
+  default     = ["10.0.7.0/24", "10.0.8.0/24", "10.0.9.0/24"]
   description = "A list of CIDR ranges for db subnets."
 }
 
@@ -60,10 +60,10 @@ variable "postgres" {
 }
 
 variable "cluster_issuer" {
-	type = object({
-		private_key = string
-		email       = string
-	})
+  type = object({
+    private_key = string
+    email       = string
+  })
 }
 
 variable "ckan_storage" {}

--- a/k8s-infrastructure/variables.tf
+++ b/k8s-infrastructure/variables.tf
@@ -1,0 +1,70 @@
+variable "project_env" {
+  type        = string
+  description = "A project namespace for the infrastructure."
+  default     = "dev"
+}
+
+variable "aws_region" {
+  default     = "us-east-1"
+  type        = string
+  description = "A valid AWS region to configure the underlying AWS SDK."
+}
+
+variable "availability_zones" {
+  default     = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  description = "A list of availability zones for subnet placement."
+}
+
+variable "private_subnet_cidr_blocks" {
+  default     = ["10.0.1.0/24", "10.0.2.0/24","10.0.3.0/24"]
+  description = "A list of CIDR ranges for private subnets."
+}
+
+variable "public_subnet_cidr_blocks" {
+  default     = ["10.0.4.0/24", "10.0.5.0/24","10.0.6.0/24"]
+  description = "A list of CIDR ranges for public subnets."
+}
+
+variable "db_subnet_cidr_blocks" {
+  default     = ["10.0.7.0/24", "10.0.8.0/24","10.0.9.0/24"]
+  description = "A list of CIDR ranges for db subnets."
+}
+
+variable "postgres" {
+  default = {
+    instance_name      = "dx-ckan-db"
+    family             = "postgres11"
+    instance_class     = "db.t3.micro"
+    instance_version   = "11.19"
+    database_name      = "ckan"
+    database_user_name = "postgres"
+    allocated_storage  = "5"
+    backup_retention   = 7
+    maintenance_window = "Mon:00:00-Mon:03:00"
+    backup_window      = "03:00-06:00"
+  }
+
+  type = object({
+    instance_name      = string
+    family             = string
+    instance_class     = string
+    database_name      = string
+    instance_version   = string
+    database_user_name = string
+    allocated_storage  = string
+    maintenance_window = string
+    backup_window      = string
+    backup_retention   = number
+  })
+
+}
+
+variable "cluster_issuer" {
+	type = object({
+		private_key = string
+		email       = string
+	})
+}
+
+variable "ckan_storage" {}
+variable "cluster_name" {}

--- a/k8s-infrastructure/versions.tf
+++ b/k8s-infrastructure/versions.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region  = var.aws_region
+  region = var.aws_region
 }
 
 terraform {

--- a/k8s-infrastructure/versions.tf
+++ b/k8s-infrastructure/versions.tf
@@ -1,0 +1,17 @@
+provider "aws" {
+  region  = var.aws_region
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.11.0"
+    }
+  }
+  required_version = "~> 1.5"
+}


### PR DESCRIPTION
This PR adds the terraform scripts needed to provision the infrastructure for wri odp

The description of files and features added is given below.

We can compare with old infrastructure and look into integrating improvements in to it as well. 


**NOTE: The information given below has been pushed as a README as well**




## Remote State and State Locking

The Terraform setup employs a remote backend for storing the state file. The remote state storage configuration is defined in the `backend.tf` file.

Additionally, to ensure safe and concurrent access to the Terraform state, the [state locking](https://developer.hashicorp.com/terraform/language/state/locking) feature is enabled, leveraging DynamoDB for this purpose.

## Directory Structure

The Terraform setup is organized into two main directories:

1. **env**: This directory contains environment-specific files (e.g., dev, staging, prod) that use the modules located in the `k8s-infrastructure` directory. Environment variables are passed from this directory to the modules in `k8s-infrastructure`.

2. **k8s-infrastructure**: This directory contains various modules for infrastructure provisioning. These modules are called from the `main.tf` file within the `k8s-infrastructure` directory, utilizing the variables provided by the `env/<env_name>` folder, where `terraform plan` and `terraform apply` commands are executed.

## IAM Service Account

An IAM Service Account user for Terraform is added without console access, with least privilege permissions (only the permissions required for provisioning the needed components). It is created to provision the architecture with tags like "Purpose: Terraform Automation" and "Application: WRI ODP" to help differentiate between different service accounts.

## k8s-infrastructure Modules

The `k8s-infrastructure` directory contains several modules, each responsible for specific infrastructure provisioning tasks. Below, we provide detailed explanations for each module:

### ecr

The `ecr` module is used for storing built Docker images, which are essential for deploying applications in your Kubernetes cluster. It ensures a reliable and versioned repository for your container images.

The module contains the following files with their functionalities:

- `main.tf`: This adds a private ECR registry with IMMUTABLE images.

### eks

The `eks` module is responsible for provisioning and managing an Amazon Elastic Kubernetes Service (EKS) cluster. EKS provides a scalable and managed Kubernetes environment, making it easier to deploy, manage, and scale containerized applications.

The module contains the following files with their functionalities:

- `main.tf`: It uses the module [terraform-aws-modules/eks/aws](https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest) for provisioning the EKS cluster with one managed node group.
  - Uses IAM Roles for Service Accounts (IRSA) to grant roles to applications running in the EKS cluster.
  - Managed node group (i.e., node group 1) with "t3.xlarge" instance type, tagged with the deployed environment.
- `iam.tf`: We create an IAM role with access to EKS with necessary permissions.
  - Provide Describe Cluster access to the role to access the cluster.
  - IAM role (eks-admin) is created, which is bound to the Kubernetes system masters RBAC group to allow full access to the Kubernetes API.
  - With trusted_role_arn, every user can assume the role if the user has needed policies attached to it.
  - Allow users to assume a role that has access to EKS.
  - Enable the EKS cluster `manage_aws_auth_configmap` and allow the role we just created in the aws_auth_roles (i.e., mapping eks-admin role with the Kubernetes system master RBAC group).
- `autoscaler-iam.tf` and `autoscaler-manifest.tf`: Uses OIDC provider for IAM role service account.
  - Adds Cluster autoscaler to automatically scale the EKS cluster using the manifest files.
- `csi-driver-iam.tf` and `csi-driver-addons.tf`: Add EBS CSI driver as an add-on to ensure that we can attach volumes to the pods along with the user permissions needed for the IAM role.
- `helm.tf`: Deploys nginx ingress controller and cert-manager.

### rds

The `rds` module handles the provisioning of a PostgreSQL database server. This database server is crucial for your applications, providing a secure and scalable storage solution for data.

The module contains the following files with their functionalities:

- `main.tf`: To create a PostgreSQL instance depending on the values provided to it via environment variables.

### s3

The `s3` module manages the provisioning of backend storage using Amazon S3. This storage is utilized by your applications to store and retrieve various data types, such as static assets, logs, and backups.

The module contains the following files with their functionalities:

- `main.tf`: Creates a private bucket for storing backend files for the WRI ODP.

### vpc

The `vpc` module takes care of provisioning a Virtual Private Cloud (VPC) and network policies for your entire infrastructure. It ensures a secure and isolated network environment for your Kubernetes cluster and associated resources.

The module contains the following files with their functionalities:

- `main.tf`: Uses the open-source module `terraform-aws-modules/vpc/aws` to deploy the VPC.
  - Uses a single NAT gateway and enables DNS hostname and DNS support.
  - Tags the VPC with the environment name.
  - Adds a security group to allow traffic to the RDS instance on port 5432.

Each of these modules plays a crucial role in building and maintaining your Kubernetes-based infrastructure. In the following sections, we will delve into the specific configurations and usage of each module.

## Usage

### How to deploy

1. Clone the repository locally and ensure that you have the credentials for the Terraform user already set up in your environment.

2. Navigate to the `env` directory corresponding to your working environment (e.g., `cd env/dev`).

3. Add the necessary environment variables in `.auto.tfvars`.

4. Run `terraform plan`. For example, if you are in the `env/dev` directory, run `terraform plan` after adding `.auto.tfvars`.

5. Run `terraform apply` once everything in the plan seems satisfactory.

These steps will allow you to deploy and manage the infrastructure efficiently.
