### PR TITLE
Update Postgres Instance and make minor changes in the existing codebase

### DIFF
--- a/env/dev/main.tf
+++ b/env/dev/main.tf
@@ -24,6 +24,7 @@ module "infrastructure" {
   ckan_storage               = var.s3_ckan_storage
   cluster_name               = var.s3_cluster_name
   cluster_issuer             = var.cluster_issuer
+  bucket_names               = var.bucket_names
 }
 
 

--- a/env/dev/variables.tf
+++ b/env/dev/variables.tf
@@ -72,3 +72,8 @@ variable "sg_rds_cidr_block" {
   type        = list(string)
   description = "The CIDR range for the RDS security Group"
 }
+
+variable "bucket_names" {
+  type = list(string)
+  default = ["ckan-dev-storage"]
+}

--- a/env/dev/variables.tf
+++ b/env/dev/variables.tf
@@ -10,29 +10,31 @@ variable "s3_cluster_name" {
 
 variable "postgres" {
   default = {
-    instance_name      = "dx-ckan-db"
-    family             = "postgres11"
-    instance_class     = "db.t3.micro"
-    instance_version   = "11.19"
-    database_name      = "ckan"
-    database_user_name = "postgres"
-    allocated_storage  = "5"
-    backup_retention   = 7
-    maintenance_window = "Mon:00:00-Mon:03:00"
-    backup_window      = "03:00-06:00"
+    instance_name         = "dx-ckan-db"
+    family                = "postgres15"
+    instance_class        = "db.t3.small"
+    instance_version      = "15.4"
+    database_name         = "ckan"
+    database_user_name    = "postgres"
+    allocated_storage     = "100"
+    max_allocated_storage = "150"
+    backup_retention      = 7
+    maintenance_window    = "Mon:00:00-Mon:03:00"
+    backup_window         = "03:00-06:00"
   }
 
   type = object({
-    instance_name      = string
-    family             = string
-    instance_class     = string
-    database_name      = string
-    instance_version   = string
-    database_user_name = string
-    allocated_storage  = string
-    maintenance_window = string
-    backup_window      = string
-    backup_retention   = number
+    instance_name         = string
+    family                = string
+    instance_class        = string
+    database_name         = string
+    instance_version      = string
+    database_user_name    = string
+    allocated_storage     = string
+    max_allocated_storage = string
+    maintenance_window    = string
+    backup_window         = string
+    backup_retention      = number
   })
 
 }
@@ -74,6 +76,6 @@ variable "sg_rds_cidr_block" {
 }
 
 variable "bucket_names" {
-  type = list(string)
+  type    = list(string)
   default = ["ckan-dev-storage"]
 }

--- a/k8s-infrastructure/main.tf
+++ b/k8s-infrastructure/main.tf
@@ -33,6 +33,7 @@ module "ckan_storage" {
   source       = "./modules/s3"
   storage      = var.ckan_storage
   cluster_name = var.cluster_name
+  bucket_names = var.bucket_names
 
 }
 

--- a/k8s-infrastructure/main.tf
+++ b/k8s-infrastructure/main.tf
@@ -10,14 +10,14 @@ module "ckan_vpc" {
 }
 
 module "ckan_eks" {
-  source                = "./modules/eks"
-  cluster_name          = var.cluster_name
-  vpc_id                = module.ckan_vpc.vpc_id
-  subnet_ids            = module.ckan_vpc.subnet_ids
+  source       = "./modules/eks"
+  cluster_name = var.cluster_name
+  vpc_id       = module.ckan_vpc.vpc_id
+  subnet_ids   = module.ckan_vpc.subnet_ids
   #aws_security_group_id = module.ckan_vpc.security_group_id
-  vpc_owner_id          = module.ckan_vpc.owner_id
-  cluster_issuer        = var.cluster_issuer
-  project_env           = var.project_env
+  vpc_owner_id   = module.ckan_vpc.owner_id
+  cluster_issuer = var.cluster_issuer
+  project_env    = var.project_env
 
 }
 

--- a/k8s-infrastructure/modules/ecr/variables.tf
+++ b/k8s-infrastructure/modules/ecr/variables.tf
@@ -1,4 +1,4 @@
-variable "cluster_name" { }
+variable "cluster_name" {}
 
 variable "ecr" {
   default = {

--- a/k8s-infrastructure/modules/eks/iam.tf
+++ b/k8s-infrastructure/modules/eks/iam.tf
@@ -18,7 +18,7 @@ module "allow_eks_access_iam_policy" {
     ]
   })
 }
-variable "vpc_owner_id" {}
+
 module "eks_admins_iam_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "5.3.1"
@@ -34,7 +34,7 @@ module "eks_admins_iam_role" {
   ]
 }
 
-module "dev_iam_user" {
+/* module "dev_iam_user" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-user"
   version = "5.3.1"
 
@@ -43,7 +43,7 @@ module "dev_iam_user" {
   create_iam_user_login_profile = false
 
   force_destroy = true
-}
+} */
 
 module "allow_assume_eks_admins_iam_policy" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
@@ -66,13 +66,16 @@ module "allow_assume_eks_admins_iam_policy" {
   })
 }
 
-module "eks_admins_iam_group" {
+module "eks_dev_group" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-group-with-policies"
   version = "5.3.1"
 
-  name                              = "eks-admin"
+  name                              = "wri-odp-dev"
   attach_iam_self_management_policy = false
   create_group                      = true
-  group_users                       = [module.dev_iam_user.iam_user_name]
+  #group_users                       = [module.dev_iam_user.iam_user_name]
   custom_group_policy_arns          = [module.allow_assume_eks_admins_iam_policy.arn]
+  tags = {
+    Description = "This group is managed by terraform for granting access to the devs to the k8s cluster"
+  }
 }

--- a/k8s-infrastructure/modules/eks/iam.tf
+++ b/k8s-infrastructure/modules/eks/iam.tf
@@ -75,7 +75,7 @@ module "eks_dev_group" {
   attach_iam_self_management_policy = false
   create_group                      = true
   #group_users                       = [module.dev_iam_user.iam_user_name]
-  custom_group_policy_arns          = [module.allow_assume_eks_admins_iam_policy.arn]
+  custom_group_policy_arns = [module.allow_assume_eks_admins_iam_policy.arn]
   tags = {
     Description = "This group is managed by terraform for granting access to the devs to the k8s cluster"
   }

--- a/k8s-infrastructure/modules/eks/iam.tf
+++ b/k8s-infrastructure/modules/eks/iam.tf
@@ -11,6 +11,7 @@ module "allow_eks_access_iam_policy" {
       {
         Action = [
           "eks:DescribeCluster",
+          "eks:ListClusters"
         ]
         Effect   = "Allow"
         Resource = "*"

--- a/k8s-infrastructure/modules/eks/main.tf
+++ b/k8s-infrastructure/modules/eks/main.tf
@@ -66,10 +66,6 @@ provider "kubernetes" {
   }
 }
 
-
-/* output "test-out" {
-  value = data.aws_eks_cluster.default.endpoint
-} */
 output "eks_oidc" {
   value = module.eks.oidc_provider_arn
 }

--- a/k8s-infrastructure/modules/eks/main.tf
+++ b/k8s-infrastructure/modules/eks/main.tf
@@ -42,7 +42,6 @@ module "eks" {
 }
 
 
-# https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2009
 data "aws_eks_cluster" "default" {
   #name = module.eks.cluster_name
   name = var.cluster_name
@@ -68,9 +67,9 @@ provider "kubernetes" {
 }
 
 
-output "test-out" {
+/* output "test-out" {
   value = data.aws_eks_cluster.default.endpoint
-}
+} */
 output "eks_oidc" {
   value = module.eks.oidc_provider_arn
 }

--- a/k8s-infrastructure/modules/eks/variables.tf
+++ b/k8s-infrastructure/modules/eks/variables.tf
@@ -4,3 +4,4 @@ variable "cluster_name" {
 variable "vpc_id" {}
 variable "subnet_ids" {}
 variable "project_env" {}
+variable "vpc_owner_id" {}

--- a/k8s-infrastructure/modules/rds/main.tf
+++ b/k8s-infrastructure/modules/rds/main.tf
@@ -7,8 +7,8 @@ module "db" {
   engine_version = var.postgres.instance_version
   instance_class = var.postgres.instance_class
 
-  allocated_storage = var.postgres.allocated_storage
-
+  allocated_storage       = var.postgres.allocated_storage
+  max_allocated_storage   = var.postgres.max_allocated_storage
   backup_retention_period = var.postgres.backup_retention
   maintenance_window      = var.postgres.maintenance_window
   backup_window           = var.postgres.backup_window

--- a/k8s-infrastructure/modules/rds/variables.tf
+++ b/k8s-infrastructure/modules/rds/variables.tf
@@ -1,28 +1,30 @@
 variable "postgres" {
   default = {
-    instance_name      = "dx-ckan-db"
-    family             = "postgres11"
-    instance_class     = "db.t3.micro"
-    instance_version   = "11.19"
-    database_name      = "ckan"
-    database_user_name = "postgres"
-    allocated_storage  = "5"
-    backup_retention   = 7
-    maintenance_window = "Mon:00:00-Mon:03:00"
-    backup_window      = "03:00-06:00"
+    instance_name         = "dx-ckan-db"
+    family                = "postgres11"
+    instance_class        = "db.t3.small"
+    instance_version      = "11.19"
+    database_name         = "ckan"
+    database_user_name    = "postgres"
+    allocated_storage     = "100"
+    max_allocated_storage = "150"
+    backup_retention      = 7
+    maintenance_window    = "Mon:00:00-Mon:03:00"
+    backup_window         = "03:00-06:00"
   }
 
   type = object({
-    instance_name      = string
-    family             = string
-    instance_class     = string
-    database_name      = string
-    instance_version   = string
-    database_user_name = string
-    allocated_storage  = string
-    maintenance_window = string
-    backup_window      = string
-    backup_retention   = number
+    instance_name         = string
+    family                = string
+    instance_class        = string
+    database_name         = string
+    instance_version      = string
+    database_user_name    = string
+    allocated_storage     = string
+    max_allocated_storage = string
+    maintenance_window    = string
+    backup_window         = string
+    backup_retention      = number
   })
 
 }

--- a/k8s-infrastructure/modules/s3/main.tf
+++ b/k8s-infrastructure/modules/s3/main.tf
@@ -1,14 +1,9 @@
-
-/* Create the bucket  */
 resource "aws_s3_bucket" "ckan_storage" {
-  bucket = "${var.cluster_name}-${var.storage}"
+  for_each = toset(var.bucket_names)
+  bucket = each.value
 }
 
 resource "aws_s3_bucket_public_access_block" "ckan_storage_acl" {
-  bucket                  = aws_s3_bucket.ckan_storage.id
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
+  for_each = toset(var.bucket_names)
+  bucket = each.value
 }
-

--- a/k8s-infrastructure/modules/s3/main.tf
+++ b/k8s-infrastructure/modules/s3/main.tf
@@ -1,9 +1,9 @@
 resource "aws_s3_bucket" "ckan_storage" {
   for_each = toset(var.bucket_names)
-  bucket = each.value
+  bucket   = each.value
 }
 
 resource "aws_s3_bucket_public_access_block" "ckan_storage_acl" {
   for_each = toset(var.bucket_names)
-  bucket = each.value
+  bucket   = each.value
 }

--- a/k8s-infrastructure/modules/s3/variables.tf
+++ b/k8s-infrastructure/modules/s3/variables.tf
@@ -6,3 +6,8 @@ variable "storage" {
 }
 
 variable "cluster_name" {}
+
+
+variable "bucket_names" {
+  type = list(string)
+}

--- a/k8s-infrastructure/modules/vpc/main.tf
+++ b/k8s-infrastructure/modules/vpc/main.tf
@@ -36,9 +36,9 @@ resource "aws_security_group" "rds" {
 
   ingress {
     description = "Allow traffic to the RDS instance"
-    from_port = 5432
-    to_port   = 5432
-    protocol  = "tcp"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
     cidr_blocks = var.sg_rds_cidr_block
   }
 }

--- a/k8s-infrastructure/variables.tf
+++ b/k8s-infrastructure/variables.tf
@@ -74,3 +74,7 @@ variable "cluster_issuer" {
 
 variable "ckan_storage" {}
 variable "cluster_name" {}
+
+variable "bucket_names" {
+  type = list(string)
+}

--- a/k8s-infrastructure/variables.tf
+++ b/k8s-infrastructure/variables.tf
@@ -38,29 +38,31 @@ variable "db_subnet_cidr_blocks" {
 
 variable "postgres" {
   default = {
-    instance_name      = "dx-ckan-db"
-    family             = "postgres11"
-    instance_class     = "db.t3.micro"
-    instance_version   = "11.19"
-    database_name      = "ckan"
-    database_user_name = "postgres"
-    allocated_storage  = "5"
-    backup_retention   = 7
-    maintenance_window = "Mon:00:00-Mon:03:00"
-    backup_window      = "03:00-06:00"
+    instance_name         = "dx-ckan-db"
+    family                = "postgres15"
+    instance_class        = "db.t3.small"
+    instance_version      = "15.4"
+    database_name         = "ckan"
+    database_user_name    = "postgres"
+    allocated_storage     = "100"
+    max_allocated_storage = "150"
+    backup_retention      = 7
+    maintenance_window    = "Mon:00:00-Mon:03:00"
+    backup_window         = "03:00-06:00"
   }
 
   type = object({
-    instance_name      = string
-    family             = string
-    instance_class     = string
-    database_name      = string
-    instance_version   = string
-    database_user_name = string
-    allocated_storage  = string
-    maintenance_window = string
-    backup_window      = string
-    backup_retention   = number
+    instance_name         = string
+    family                = string
+    instance_class        = string
+    database_name         = string
+    instance_version      = string
+    database_user_name    = string
+    allocated_storage     = string
+    max_allocated_storage = string
+    maintenance_window    = string
+    backup_window         = string
+    backup_retention      = number
   })
 
 }

--- a/k8s-infrastructure/versions.tf
+++ b/k8s-infrastructure/versions.tf
@@ -1,6 +1,5 @@
 provider "aws" {
   region = var.aws_region
-  profile = "wri-terraform"
 }
 
 terraform {

--- a/k8s-infrastructure/versions.tf
+++ b/k8s-infrastructure/versions.tf
@@ -1,5 +1,6 @@
 provider "aws" {
   region = var.aws_region
+  profile = "wri-terraform"
 }
 
 terraform {


### PR DESCRIPTION
This PR adds

* Addition of multiple buckets depending on the variables provided instead of just creating one storage bucket i.e
  ```
  variable "bucket_names" {
    type    = list(string)
    default = ["ckan-dev-storage"]
  }
  ```
* Upgrades postgres to 15.4 and db.t3.small. Also increased the storage space to 100 GiB.
* Also renames `eks_admins_iam_group` to `eks_dev_group` for all the developers on AWS to have access to the EKS cluster
