### PR TITLE
Add multiple repos for apps in the ECR

### DIFF
--- a/env/dev/main.tf
+++ b/env/dev/main.tf
@@ -25,6 +25,7 @@ module "infrastructure" {
   cluster_name               = var.s3_cluster_name
   cluster_issuer             = var.cluster_issuer
   bucket_names               = var.bucket_names
+  ecr_repositories           = var.ecr_repositories
 }
 
 

--- a/env/dev/variables.tf
+++ b/env/dev/variables.tf
@@ -81,6 +81,6 @@ variable "bucket_names" {
 }
 
 variable "ecr_repositories" {
-  type = list(string)
-  default = ["ckan-ecr","frontend-ecr","datapusher-ecr"]
+  type    = list(string)
+  default = ["ckan-ecr", "frontend-ecr", "datapusher-ecr"]
 }

--- a/env/dev/variables.tf
+++ b/env/dev/variables.tf
@@ -79,3 +79,8 @@ variable "bucket_names" {
   type    = list(string)
   default = ["ckan-dev-storage"]
 }
+
+variable "ecr_repositories" {
+  type = list(string)
+  default = ["ckan-ecr","frontend-ecr","datapusher-ecr"]
+}

--- a/k8s-infrastructure/main.tf
+++ b/k8s-infrastructure/main.tf
@@ -40,5 +40,6 @@ module "ckan_storage" {
 module "ckan_ecr" {
   source       = "./modules/ecr"
   cluster_name = var.cluster_name
+  ecr_repositories = var.ecr_repositories
 }
 

--- a/k8s-infrastructure/main.tf
+++ b/k8s-infrastructure/main.tf
@@ -38,8 +38,8 @@ module "ckan_storage" {
 }
 
 module "ckan_ecr" {
-  source       = "./modules/ecr"
-  cluster_name = var.cluster_name
+  source           = "./modules/ecr"
+  cluster_name     = var.cluster_name
   ecr_repositories = var.ecr_repositories
 }
 

--- a/k8s-infrastructure/modules/ecr/main.tf
+++ b/k8s-infrastructure/modules/ecr/main.tf
@@ -5,3 +5,12 @@ resource "aws_ecr_repository" "default" {
     scan_on_push = var.ecr.scan_on_push
   }
 }
+
+resource "aws_ecr_repository" "odp-ecr" {
+  for_each = toset(var.ecr_repositories)
+  name                 = each.value
+  image_tag_mutability = var.ecr.mutability
+  image_scanning_configuration {
+    scan_on_push = var.ecr.scan_on_push
+  }
+}

--- a/k8s-infrastructure/modules/ecr/main.tf
+++ b/k8s-infrastructure/modules/ecr/main.tf
@@ -1,3 +1,14 @@
+resource "aws_ecr_repository" "odp-ecr" {
+  for_each             = toset(var.ecr_repositories)
+  name                 = each.value
+  image_tag_mutability = var.ecr.mutability
+  image_scanning_configuration {
+    scan_on_push = var.ecr.scan_on_push
+  }
+}
+
+# This ECR is not being used and we are going to remove in future
+# once we verify no service is depending on it.
 resource "aws_ecr_repository" "default" {
   name                 = "${var.cluster_name}-ecr"
   image_tag_mutability = var.ecr.mutability
@@ -6,11 +17,3 @@ resource "aws_ecr_repository" "default" {
   }
 }
 
-resource "aws_ecr_repository" "odp-ecr" {
-  for_each = toset(var.ecr_repositories)
-  name                 = each.value
-  image_tag_mutability = var.ecr.mutability
-  image_scanning_configuration {
-    scan_on_push = var.ecr.scan_on_push
-  }
-}

--- a/k8s-infrastructure/modules/ecr/variables.tf
+++ b/k8s-infrastructure/modules/ecr/variables.tf
@@ -11,3 +11,7 @@ variable "ecr" {
     mutability   = string
   })
 }
+
+variable "ecr_repositories" {
+  type = list(string)
+}

--- a/k8s-infrastructure/variables.tf
+++ b/k8s-infrastructure/variables.tf
@@ -80,3 +80,7 @@ variable "cluster_name" {}
 variable "bucket_names" {
   type = list(string)
 }
+
+variable "ecr_repositories" {
+  type = list(string)
+}


### PR DESCRIPTION
This PR adds ECR repositories based on the variables provided as names for different apps.
Currently we added three repostories for adding images of
* CKAN
* Frontend
* Datapusher

Note: We havent removed the old `resource "aws_ecr_repository" "default"` yet but will be removed in the future as it is replaced by CKAN app's dedicated ECR repository.