### PR TITLE
Fixes terraform changes in the state

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ The Terraform setup is organized into two main directories:
 
 2. **k8s-infrastructure**: This directory contains various modules for infrastructure provisioning. These modules are called from the `main.tf` file within the `k8s-infrastructure` directory, utilizing the variables provided by the `env/<env_name>` folder, where `terraform plan` and `terraform apply` commands are executed.
 
+## Usage
+
+### How to deploy
+
+1. Clone the repository locally and ensure that you have the credentials for the Terraform user already set up in your environment. You can use the terraform service account user key (can be created through IAM) to get connected.
+
+2. Navigate to the `env` directory corresponding to your working environment (e.g., `cd env/dev`).
+
+3. Add the necessary environment variables in `.auto.tfvars`. Available in the [secrets repo](https://github.com/wri/wri-odp-secrets/blob/main/infrastructure/.auto.tfvars)
+
+4. Run `terraform plan -var-file=.auto.tfvars`. For example, if you are in the `env/dev` directory, run `terraform plan` after adding `.auto.tfvars`.
+
+5. Run `terraform apply -var-file=.auto.tfvars` once everything in the plan seems satisfactory.
+
+These steps will allow you to deploy and manage the infrastructure efficiently.
+
 ## IAM Users and Service Accounts
 
 An IAM Service Account user for Terraform is added without console access, with least privilege permissions (only the permissions required for provisioning the needed components). It is created to provision the architecture with tags like "Purpose: Terraform Automation" and "Application: WRI ODP" to help differentiate between different service accounts.
@@ -207,18 +223,3 @@ The module contains the following files with their functionalities:
 
 Each of these modules plays a crucial role in building and maintaining your Kubernetes-based infrastructure. In the following sections, we will delve into the specific configurations and usage of each module.
 
-## Usage
-
-### How to deploy
-
-1. Clone the repository locally and ensure that you have the credentials for the Terraform user already set up in your environment.
-
-2. Navigate to the `env` directory corresponding to your working environment (e.g., `cd env/dev`).
-
-3. Add the necessary environment variables in `.auto.tfvars`.
-
-4. Run `terraform plan`. For example, if you are in the `env/dev` directory, run `terraform plan` after adding `.auto.tfvars`.
-
-5. Run `terraform apply` once everything in the plan seems satisfactory.
-
-These steps will allow you to deploy and manage the infrastructure efficiently.

--- a/env/dev/variables.tf
+++ b/env/dev/variables.tf
@@ -13,7 +13,7 @@ variable "postgres" {
     instance_name         = "dx-ckan-db"
     family                = "postgres15"
     instance_class        = "db.t3.small"
-    instance_version      = "15.4"
+    instance_version      = "15.5"
     database_name         = "ckan"
     database_user_name    = "postgres"
     allocated_storage     = "100"

--- a/env/dev/variables.tf
+++ b/env/dev/variables.tf
@@ -41,7 +41,7 @@ variable "postgres" {
 
 variable "cluster_issuer" {
   default = {
-    private_key = "key"
+    #private_key = "key"
     email       = "test@email.com"
   }
 }

--- a/k8s-infrastructure/modules/ecr/main.tf
+++ b/k8s-infrastructure/modules/ecr/main.tf
@@ -9,11 +9,11 @@ resource "aws_ecr_repository" "odp-ecr" {
 
 # This ECR is not being used and we are going to remove in future
 # once we verify no service is depending on it.
-resource "aws_ecr_repository" "default" {
+/* resource "aws_ecr_repository" "default" {
   name                 = "${var.cluster_name}-ecr"
   image_tag_mutability = var.ecr.mutability
   image_scanning_configuration {
     scan_on_push = var.ecr.scan_on_push
   }
-}
+} */
 

--- a/k8s-infrastructure/modules/eks/helm.tf
+++ b/k8s-infrastructure/modules/eks/helm.tf
@@ -48,7 +48,7 @@ resource "helm_release" "ngnix_ingress" {
 
 variable "cluster_issuer" {
   type = object({
-    private_key = string
+    #private_key = string
     email       = string
   })
 }
@@ -57,5 +57,5 @@ module "cert_manager" {
   source                                 = "terraform-iaac/cert-manager/kubernetes"
   version                                = "2.6.0"
   cluster_issuer_email                   = var.cluster_issuer.email
-  cluster_issuer_private_key_secret_name = var.cluster_issuer.private_key
+  #cluster_issuer_private_key_secret_name = var.cluster_issuer.private_key
 }

--- a/k8s-infrastructure/modules/eks/main.tf
+++ b/k8s-infrastructure/modules/eks/main.tf
@@ -23,7 +23,7 @@ module "eks" {
       instance_types = ["t3.xlarge"]
 
       min_size     = 1
-      max_size     = 5
+      max_size     = 6
       desired_size = 3
     }
   }

--- a/k8s-infrastructure/modules/eks/versions.tf
+++ b/k8s-infrastructure/modules/eks/versions.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14.0"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.2"
     }
   }
 } 

--- a/k8s-infrastructure/modules/rds/main.tf
+++ b/k8s-infrastructure/modules/rds/main.tf
@@ -16,9 +16,16 @@ module "db" {
   db_name  = var.postgres.database_name
   username = var.postgres.database_user_name
   port     = 5432
+  multi_az = true
 
   db_subnet_group_name = var.db_subnet_group
   vpc_security_group_ids = [
     var.security_group_rds_id
+  ]
+  parameters = [
+    {
+      name  = "idle_session_timeout"
+      value = "3600000"
+    }
   ]
 }

--- a/k8s-infrastructure/variables.tf
+++ b/k8s-infrastructure/variables.tf
@@ -41,7 +41,7 @@ variable "postgres" {
     instance_name         = "dx-ckan-db"
     family                = "postgres15"
     instance_class        = "db.t3.small"
-    instance_version      = "15.4"
+    instance_version      = "15.5"
     database_name         = "ckan"
     database_user_name    = "postgres"
     allocated_storage     = "100"

--- a/k8s-infrastructure/variables.tf
+++ b/k8s-infrastructure/variables.tf
@@ -69,7 +69,7 @@ variable "postgres" {
 
 variable "cluster_issuer" {
   type = object({
-    private_key = string
+    #private_key = string
     email       = string
   })
 }


### PR DESCRIPTION
This PR fixes and syncs the codebase to the current state of the deployed infrastructure

- README is a little more detailed now
- Postgres version and deployment strategy (multi-az) is synced
- Deprecated provider for kubectl is removed and a new one is added as given in the documentation of the module
- `idle_session_timeout` parameter is added for the db to close idle connections
- Number of max. nodes is increased to six as it reaching limit now and deploying new changes is a bit difficult now. That is now resolved by this.
- Also removes an ecr that is not being used anymore