### PR TITLE
Upgrade Kubernetes to 1.32 and Update Related Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,21 @@ The Terraform setup is organized into two main directories:
 
 ### How to deploy
 
-1. Clone the repository locally and ensure that you have the credentials for the Terraform user already set up in your environment. You can use the terraform service account user key (can be created through IAM) to get connected. For example:
-```
+1. Clone the repository locally and ensure that the credentials for the Terraform user are already set up in your environment. You can use the Terraform service account user key (which can be created through IAM) to establish the connection. For example:
+
+```bash
 export AWS_ACCESS_KEY_ID="YOUR_AWS_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="YOUR_AWS_SECRET_ACCESS_KEY"
 export AWS_DEFAULT_REGION="us-east-1"
 ```
+
+Add the Terraform service account key to the `wri-aws-terraform` profile, as this profile is referenced in the AWS provider block. To do so, run:
+
+```bash
+aws configure --profile wri-aws-terraform
+```
+
+and enter the Terraform service account credentials from IAM when prompted.
 
 2. Navigate to the `env` directory corresponding to your working environment (e.g., `cd env/dev`).
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,12 @@ The Terraform setup is organized into two main directories:
 
 ### How to deploy
 
-1. Clone the repository locally and ensure that you have the credentials for the Terraform user already set up in your environment. You can use the terraform service account user key (can be created through IAM) to get connected.
+1. Clone the repository locally and ensure that you have the credentials for the Terraform user already set up in your environment. You can use the terraform service account user key (can be created through IAM) to get connected. For example:
+```
+export AWS_ACCESS_KEY_ID="YOUR_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="YOUR_AWS_SECRET_ACCESS_KEY"
+export AWS_DEFAULT_REGION="us-east-1"
+```
 
 2. Navigate to the `env` directory corresponding to your working environment (e.g., `cd env/dev`).
 

--- a/env/dev/main.tf
+++ b/env/dev/main.tf
@@ -10,6 +10,7 @@ terraform {
 
 provider "aws" {
   region  = var.aws_region
+  profile = "wri-aws-terraform"
 }
 
 module "infrastructure" {
@@ -26,6 +27,7 @@ module "infrastructure" {
   cluster_issuer             = var.cluster_issuer
   bucket_names               = var.bucket_names
   ecr_repositories           = var.ecr_repositories
+  csi_driver_addon_version   = var.csi_driver_addon_version
 }
 
 

--- a/env/dev/variables.tf
+++ b/env/dev/variables.tf
@@ -12,8 +12,8 @@ variable "postgres" {
   default = {
     instance_name         = "dx-ckan-db"
     family                = "postgres15"
-    instance_class        = "db.t3.small"
-    instance_version      = "15.5"
+    instance_class        = "db.m5.large"
+    instance_version      = "15.12"
     database_name         = "ckan"
     database_user_name    = "postgres"
     allocated_storage     = "100"
@@ -84,3 +84,5 @@ variable "ecr_repositories" {
   type    = list(string)
   default = ["ckan-ecr", "frontend-ecr", "datapusher-ecr"]
 }
+
+variable "csi_driver_addon_version" {}

--- a/k8s-infrastructure/main.tf
+++ b/k8s-infrastructure/main.tf
@@ -18,6 +18,7 @@ module "ckan_eks" {
   vpc_owner_id   = module.ckan_vpc.owner_id
   cluster_issuer = var.cluster_issuer
   project_env    = var.project_env
+  csi_driver_addon_version = var.csi_driver_addon_version
 
 }
 

--- a/k8s-infrastructure/modules/eks/autoscaler-manifest.tf
+++ b/k8s-infrastructure/modules/eks/autoscaler-manifest.tf
@@ -173,7 +173,7 @@ spec:
         fsGroup: 65534
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.25.3
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.3
           name: cluster-autoscaler
           resources:
             limits:

--- a/k8s-infrastructure/modules/eks/csi-driver-addons.tf
+++ b/k8s-infrastructure/modules/eks/csi-driver-addons.tf
@@ -1,6 +1,6 @@
 resource "aws_eks_addon" "csi_driver" {
   cluster_name             = module.eks.cluster_name
   addon_name               = "aws-ebs-csi-driver"
-  addon_version            = "v1.22.0-eksbuild.2"
+  addon_version            = var.csi_driver_addon_version
   service_account_role_arn = aws_iam_role.eks_ebs_csi_driver.arn
 }

--- a/k8s-infrastructure/modules/eks/helm.tf
+++ b/k8s-infrastructure/modules/eks/helm.tf
@@ -1,9 +1,9 @@
 provider "helm" {
-  kubernetes {
+  kubernetes =   {
     host                   = data.aws_eks_cluster.default.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.default.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.default.token
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       args        = ["eks", "get-token", "--cluster-name", var.cluster_name]
       command     = "aws"
@@ -15,6 +15,7 @@ resource "helm_release" "sealed_secrets" {
   name       = "sealed-secrets-controller"
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "sealed-secrets"
+  version    = "1.5.2"
 }
 
 resource "helm_release" "ngnix_ingress" {
@@ -22,28 +23,25 @@ resource "helm_release" "ngnix_ingress" {
   chart      = "ingress-nginx"
   repository = "https://kubernetes.github.io/ingress-nginx"
   namespace  = "nginx-ingress"
-  version    = "4.4.0"
+  version    = "4.10.1"
 
-  set {
+  set = [ {
     name  = "rbac.create"
     value = true
-  }
-
-  set {
+  },
+  {
     name  = "controller.service.externalTrafficPolicy"
     value = "Local"
-  }
-
-  set {
+  },
+  {
     name  = "controller.publishService.enabled"
     value = true
-  }
-
-  set {
+  },
+  {
     name  = "controller.replicaCount"
     value = "3"
-  }
-}
+  }]
+} 
 
 
 variable "cluster_issuer" {
@@ -55,7 +53,7 @@ variable "cluster_issuer" {
 
 module "cert_manager" {
   source                                 = "terraform-iaac/cert-manager/kubernetes"
-  version                                = "2.6.0"
+  version                                = "3.0.1"
   cluster_issuer_email                   = var.cluster_issuer.email
   #cluster_issuer_private_key_secret_name = var.cluster_issuer.private_key
 }

--- a/k8s-infrastructure/modules/eks/main.tf
+++ b/k8s-infrastructure/modules/eks/main.tf
@@ -4,7 +4,7 @@ module "eks" {
   version = "19.16.0"
 
   cluster_name                    = var.cluster_name
-  cluster_version                 = "1.25"
+  cluster_version                 = "1.32"
   cluster_endpoint_private_access = true
   cluster_endpoint_public_access  = true
   vpc_id                          = var.vpc_id

--- a/k8s-infrastructure/modules/eks/variables.tf
+++ b/k8s-infrastructure/modules/eks/variables.tf
@@ -5,3 +5,5 @@ variable "vpc_id" {}
 variable "subnet_ids" {}
 variable "project_env" {}
 variable "vpc_owner_id" {}
+
+variable "csi_driver_addon_version" {}

--- a/k8s-infrastructure/modules/eks/versions.tf
+++ b/k8s-infrastructure/modules/eks/versions.tf
@@ -4,5 +4,9 @@ terraform {
       source  = "alekc/kubectl"
       version = ">= 2.0.2"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0.2"
+    }
   }
 } 

--- a/k8s-infrastructure/modules/rds/main.tf
+++ b/k8s-infrastructure/modules/rds/main.tf
@@ -26,6 +26,11 @@ module "db" {
     {
       name  = "idle_session_timeout"
       value = "3600000"
+    },
+    {
+      name = "max_connections"
+      value = "1000"
+      apply_method = "pending-reboot"
     }
   ]
 }

--- a/k8s-infrastructure/modules/rds/variables.tf
+++ b/k8s-infrastructure/modules/rds/variables.tf
@@ -2,7 +2,7 @@ variable "postgres" {
   default = {
     instance_name         = "dx-ckan-db"
     family                = "postgres11"
-    instance_class        = "db.t3.small"
+    instance_class        = "db.m5.large"
     instance_version      = "11.19"
     database_name         = "ckan"
     database_user_name    = "postgres"

--- a/k8s-infrastructure/variables.tf
+++ b/k8s-infrastructure/variables.tf
@@ -40,8 +40,8 @@ variable "postgres" {
   default = {
     instance_name         = "dx-ckan-db"
     family                = "postgres15"
-    instance_class        = "db.t3.small"
-    instance_version      = "15.5"
+    instance_class        = "db.m5.large"
+    instance_version      = "15.12"
     database_name         = "ckan"
     database_user_name    = "postgres"
     allocated_storage     = "100"
@@ -84,3 +84,5 @@ variable "bucket_names" {
 variable "ecr_repositories" {
   type = list(string)
 }
+
+variable "csi_driver_addon_version"{}

--- a/k8s-infrastructure/versions.tf
+++ b/k8s-infrastructure/versions.tf
@@ -1,5 +1,6 @@
 provider "aws" {
   region = var.aws_region
+  profile = "wri-aws-terraform"
 }
 
 terraform {
@@ -10,7 +11,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.11.0"
+      version = "~> 3.0.2"
     }
   }
   required_version = "~> 1.5"


### PR DESCRIPTION
### 🔄 Summary of Changes

* **EKS Cluster**

  * Upgraded version from `1.29` → `1.32`
  * Platform version updated from `eks.7` → `eks.23`
  * ✅ In-place upgrade (no cluster replacement)

* **RDS Instance**

  * Availability Zone drift corrected: `us-east-1a` → `us-east-1b`
  * Engine version drift corrected: `15.5` → `15.12`
  * ✅ In-place updates (no replacement)

* **Helm Releases**

  * `nginx_ingress`, `sealed_secrets`, and `cert_manager` chart versions upgraded
  * Minor `set` value adjustments
  * ✅ In-place helm release updates

* **Cluster Autoscaler**

  * Image updated: `v1.29.3` → `v1.32.3`
  * ✅ In-place update

* **CSI Driver Addon (K8s cluster)**

  * Variable csi_driver_addon_version is added which can be set in [.auto.tfvars](https://github.com/wri/wri-odp-secrets/blob/main/infrastructure/.auto.tfvars) variables to upgrade/pin CSI addon driver
  * ✅ In-place update

* **README**

  * Updated info. regarding the setup
---

### 📝 Reviewer Note

These changes primarily reconcile **manual upgrades** (EKS version, RDS patching, helm chart updates).
All updates are **in-place and safe to apply** (are already applied to the infrastructure during the upgrade process). 
